### PR TITLE
Find the law of motion using Machine Learning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "00c1fa90-8c22-4eec-9c74-87e4de363053"
 authors = ["Fabio Stohler <58552478+Fabio-Stohler@users.noreply.github.com>"]
 version = "0.1.0"
 
-
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
@@ -18,6 +17,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FieldMetadata = "bf96fef3-21d2-5d20-8afa-0e7d4c32a885"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Flatten = "4c728ea3-d9ee-5c9a-9642-b6f7d7dc04fa"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"


### PR DESCRIPTION
So far, we find the law of motion for capital using standard OLS regressions. To increase the precision, we now fit a neural network to find the perceived law of motion for capital. The pull request solves issue #15.